### PR TITLE
Require the name: keyword when creating executors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*~
 *.iml
 _build
 .idea

--- a/dylan-package.json
+++ b/dylan-package.json
@@ -1,0 +1,8 @@
+{
+    "name": "concurrency",
+    "description": "Concurrency utilities",
+    "version": "0.2.0",
+    "dependencies": [ ],
+    "dev-dependencies": [ "testworks" ],
+    "url": "https://github.com/dylan-foundry/concurrency"
+}

--- a/executor.dylan
+++ b/executor.dylan
@@ -4,8 +4,8 @@ author: Ingo Albrecht <prom@berlin.ccc.de>
 copyright: See accompanying file LICENSE
 
 define abstract class <executor> (<object>)
-  constant slot executor-name :: <string> = "executor",
-    init-keyword: name:;
+  constant slot executor-name :: <string>,
+    required-init-keyword: name:;
 end class;
 
 // Request that this executor do some work.

--- a/tests/concurrency-test-suite-app.lid
+++ b/tests/concurrency-test-suite-app.lid
@@ -1,4 +1,5 @@
 library: concurrency-test-suite-app
+target-type: executable
 executable: concurrency-test-suite-app
 files: concurrency-test-suite-app-library
        concurrency-test-suite-app

--- a/tests/concurrency-test-suite.lid
+++ b/tests/concurrency-test-suite.lid
@@ -1,4 +1,5 @@
 library: concurrency-test-suite
+target-type: dll
 files: concurrency-test-suite-library
        concurrency-test-suite
 

--- a/thread-executor.dylan
+++ b/thread-executor.dylan
@@ -62,7 +62,7 @@ define method initialize (executor :: <single-thread-executor>, #rest args, #key
   next-method();
   let threads = make(<simple-object-vector>, size: 1);
   threads[0] := make(<thread>,
-                     name: concatenate(executor-name(executor), " worker"),
+                     name: executor-name(executor),
                      function: curry(%executor-thread, executor, 0));
   executor-threads(executor) := threads;
 end method;
@@ -78,11 +78,10 @@ define method initialize (executor :: <fixed-thread-executor>, #rest args, #key,
   next-method();
   let size = executor-thread-count(executor);
   let threads = make(<simple-object-vector>, size: size);
+  let name = executor-name(executor);
   for(id from 0 below size)
     threads[id] := make(<thread>,
-                        name: concatenate(executor-name(executor),
-                                          " worker ",
-                                          integer-to-string(id)),
+                        name: concatenate(name, " ", integer-to-string(id)),
                         function: curry(%executor-thread, executor, id));
   end for;
   executor-threads(executor) := threads;


### PR DESCRIPTION
And other minor updates. See commit messages.